### PR TITLE
Fix #30 - messages from non-contact users are handled incorrectly

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ class App extends MatrixPuppetBridgeBase {
     if (contact) {
       payload.senderName = contact.displayName;
       payload.avatarUrl = contact.profile.avatarUrl;
-    } else if (data.sender.indexOf(":") =! -1) {
-      payload.senderName = data.sender.substr(data.sender.indexOf(":")+1);
+    } else if (id.indexOf(":") !== -1) {
+      payload.senderName = id.substr(id.indexOf(":")+1);
       payload.avatarUrl = 'https://avatars.skype.com/v1/avatars/' + entities.encode(payload.senderName) + '/public?returnDefaultImage=false&cacheHeaders=true';
     } else {
       payload.senderName = id;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "concat-stream": "^1.6.0",
     "debug": "^2.6.8",
     "html-entities": "^1.2.1",
-    "matrix-puppet-bridge": "github:matrix-hacks/matrix-puppet-bridge#c16ac9f",
+    "matrix-puppet-bridge": "github:matrix-hacks/matrix-puppet-bridge#219d46f",
     "mime-types": "^2.1.14",
     "needle": "^1.4.5",
     "skype-http": "^0.0.15",


### PR DESCRIPTION
This fixes the exception issue, from what I see locally.

Unfortunately, there could be another issue, which I don't understand at the moment. For some reason created puppet users are not added to the room which causes the same problem - inability to see their messages. But this can be remedied by launching the bridge again.